### PR TITLE
feat(plugin): nvim-lintにactionlintの設定を追加

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -40,6 +40,31 @@ return function()
     end,
   })
 
+  vim.diagnostic.config({
+    float = {
+      border = "single",
+    },
+    severity_sort = true,
+    signs = {
+      priority = 9999,
+      -- Only for warnings and errors
+      severity = { min = "HINT", max = "ERROR" },
+    },
+    underline = true,
+    update_in_insert = false,
+    virtual_text = {
+      format = function(diagnostic)
+        return string.format("%s  %s", diagnostic.severity, diagnostic.message)
+      end,
+      prefix = "",
+      spacing = 2,
+      severity = { min = "ERROR", max = "ERROR" },
+      suffix = function(diagnostic)
+        return diagnostic.source and " [" .. diagnostic.source .. "]" or ""
+      end,
+    },
+  })
+
   --[[
   -- LSP configurations
   -- nvim-lspconfigが提供するLSP設定は以下を参照

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -40,6 +40,8 @@ return function()
     end,
   })
 
+  -- Diagnostic
+  -- `:h diagnostic-severity`を参照
   vim.diagnostic.config({
     float = {
       border = "single",
@@ -47,7 +49,7 @@ return function()
     severity_sort = true,
     signs = {
       priority = 9999,
-      -- Only for warnings and errors
+      -- signはHINT、INFO、WARN、ERRORを表示する
       severity = { min = "HINT", max = "ERROR" },
     },
     underline = true,
@@ -58,6 +60,7 @@ return function()
       end,
       prefix = "",
       spacing = 2,
+      -- virtual_textはERRORのみを表示
       severity = { min = "ERROR", max = "ERROR" },
       suffix = function(diagnostic)
         return diagnostic.source and " [" .. diagnostic.source .. "]" or ""

--- a/lua/plugins/nvim-lint.lua
+++ b/lua/plugins/nvim-lint.lua
@@ -5,6 +5,7 @@ return function()
     bash = { "shellcheck" },
     nix = { "statix" },
     lua = { "luacheck" },
+    json = { "jsonlint" },
     -- TODO: BiomeのCSSのLint機能が追加されたら削除できないか確認する
     css = { "stylelint" },
     scss = { "stylelint" },
@@ -13,9 +14,14 @@ return function()
   -- Lua
   lint.linters.luacheck.args = { "--globals", "vim", "--no-max-line-length" }
 
-  vim.api.nvim_create_autocmd({ "BufWritePost" }, {
+  vim.api.nvim_create_autocmd({ "BufEnter", "BufWritePost" }, {
     callback = function()
-      require("lint").try_lint()
+      local buf = vim.api.nvim_buf_get_name(0)
+      if string.find(buf, "%.github/workflows/.*%.yml") then
+        lint.try_lint("actionlint", { cwd = vim.loop.cwd() })
+      else
+        lint.try_lint()
+      end
     end,
   })
 end

--- a/lua/plugins/spec.nix
+++ b/lua/plugins/spec.nix
@@ -159,6 +159,7 @@ in rec {
       shellcheck
       statix # For nix
       stylelint
+      actionlint
     ];
   };
 


### PR DESCRIPTION
- `.github/workflows/`以下の{yaml,yml}ファイルでのみactionlintが実行されるように設定
- Diagnostic
  - SignはHint, INFO, WARN, ERRORを表示するように設定
  - virtual_textはERRORのみを表示するように設定
