### PR TITLE
chore: actionlintのcwdの取得方法を変更

### DIFF
--- a/lua/plugins/nvim-lint.lua
+++ b/lua/plugins/nvim-lint.lua
@@ -18,7 +18,7 @@ return function()
     callback = function()
       local buf = vim.api.nvim_buf_get_name(0)
       if string.find(buf, "%.github/workflows/.*%.yml") then
-        lint.try_lint("actionlint", { cwd = vim.loop.cwd() })
+        lint.try_lint("actionlint", { cwd = vim.fs.root(0, ".github") })
       else
         lint.try_lint()
       end


### PR DESCRIPTION
## `vim.fs.root()` と `vim.loop.cwd()`の特徴と違い

1. `vim.loop.cwd()`
   - 現在の作業ディレクトリ（Current Working Directory）を返します。
   - プロセスが現在動作しているディレクトリを示します。
   - 通常、エディタを開いたディレクトリや、`:cd` コマンドで変更したディレクトリになります。

2. `vim.fs.root()`
   - プロジェクトのルートディレクトリを見つけて返します。
   - 特定のマーカーファイル（例：.git, .hg, .svn など）を探して、プロジェクトのトップレベルディレクトリを特定します。
   - 現在のファイルやディレクトリから親ディレクトリを遡って探索します。

### 主な違い
- `vim.loop.cwd()` は現在の作業ディレクトリを返しますが、これはプロジェクトのルートと必ずしも一致しません。
- `vim.fs.root()` はプロジェクト構造を理解し、プロジェクトのルートディレクトリを特定しようとします。

### 使用例
- `vim.loop.cwd()` は単純に現在の作業ディレクトリが必要な場合に使用します。
- `vim.fs.root()` はプロジェクト全体に関連する操作（例：プロジェクト全体の検索、設定ファイルの読み込みなど）を行う際に使用します。

### 結論
- GitHub Actionsの`.github`ディレクトリはリポジトリで1つだけなので`vim.fs.root()`を使用して`cwd`を設定したほうが良い